### PR TITLE
Remove the trailing `.` from the dns name returned by net.LookupCNAME

### DIFF
--- a/pkg/controller/storage/v2beta2/cluster.go
+++ b/pkg/controller/storage/v2beta2/cluster.go
@@ -771,7 +771,7 @@ func getClusterDomain() string {
 		if err != nil {
 			return "cluster.local"
 		}
-		clusterDomain = strings.TrimPrefix(cname, apiSvc+".")
+		clusterDomain = strings.TrimSuffix(strings.TrimPrefix(cname, apiSvc + "."), ".")
 	}
 	return clusterDomain
 }


### PR DESCRIPTION
This is an example of result `kubernetes.default.svc.dev.tost.menlo.aetherproject.net.`