### PR TITLE
setting default log level to INFO

### DIFF
--- a/cmd/atomix-raft-storage-controller/main.go
+++ b/cmd/atomix-raft-storage-controller/main.go
@@ -6,7 +6,10 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"strings"
+
 	core "github.com/atomix/atomix-controller/pkg/apis/core/v2beta1"
 	primitives "github.com/atomix/atomix-controller/pkg/apis/primitives/v2beta1"
 	logutil "github.com/atomix/atomix-controller/pkg/controller/util/log"
@@ -26,6 +29,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
+var (
+	logLevel = flag.String("log_level", "INFO", "Set the log level (DEBUG, INFO, WARN, ERROR)")
+)
+
+func stringToLogLevel(l string) logging.Level {
+	switch strings.ToLower(l) {
+	case "debug":
+		return logging.DebugLevel
+	case "info":
+		return logging.InfoLevel
+	case "warn":
+		return logging.WarnLevel
+	case "error":
+		return logging.ErrorLevel
+
+	default:
+		return logging.InfoLevel
+	}
+}
+
 var log = logging.GetLogger("main")
 
 func printVersion() {
@@ -34,7 +57,8 @@ func printVersion() {
 }
 
 func main() {
-	logging.SetLevel(logging.InfoLevel)
+	flag.Parse()
+	logging.SetLevel(stringToLogLevel(*logLevel))
 	logf.SetLogger(logutil.NewControllerLogger("atomix", "controller", "raft"))
 
 	var namespace string

--- a/cmd/atomix-raft-storage-driver/main.go
+++ b/cmd/atomix-raft-storage-driver/main.go
@@ -5,7 +5,14 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
 	protocolapi "github.com/atomix/atomix-api/go/atomix/protocol"
 	"github.com/atomix/atomix-go-framework/pkg/atomix/cluster"
 	"github.com/atomix/atomix-go-framework/pkg/atomix/driver"
@@ -21,15 +28,31 @@ import (
 	"github.com/atomix/atomix-go-framework/pkg/atomix/driver/proxy/rsm/set"
 	"github.com/atomix/atomix-go-framework/pkg/atomix/driver/proxy/rsm/value"
 	"github.com/atomix/atomix-go-framework/pkg/atomix/logging"
-	"os"
-	"os/signal"
-	"strconv"
-	"strings"
-	"syscall"
 )
 
+var (
+	logLevel = flag.String("log_level", "INFO", "Set the log level (DEBUG, INFO, WARN, ERROR)")
+)
+
+func stringToLogLevel(l string) logging.Level {
+	switch strings.ToLower(l) {
+	case "debug":
+		return logging.DebugLevel
+	case "info":
+		return logging.InfoLevel
+	case "warn":
+		return logging.WarnLevel
+	case "error":
+		return logging.ErrorLevel
+
+	default:
+		return logging.InfoLevel
+	}
+}
+
 func main() {
-	logging.SetLevel(logging.DebugLevel)
+	flag.Parse()
+	logging.SetLevel(stringToLogLevel(*logLevel))
 
 	address := os.Args[1]
 	parts := strings.Split(address, ":")

--- a/cmd/atomix-raft-storage-node/main.go
+++ b/cmd/atomix-raft-storage-node/main.go
@@ -6,7 +6,14 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
 	protocolapi "github.com/atomix/atomix-api/go/atomix/protocol"
 	"github.com/atomix/atomix-go-framework/pkg/atomix/cluster"
 	"github.com/atomix/atomix-go-framework/pkg/atomix/logging"
@@ -23,16 +30,33 @@ import (
 	"github.com/atomix/atomix-raft-storage/pkg/storage/config"
 	"github.com/gogo/protobuf/jsonpb"
 	"google.golang.org/grpc"
-	"io/ioutil"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 const monitoringPort = 5000
 
+var (
+	logLevel = flag.String("log_level", "INFO", "Set the log level (DEBUG, INFO, WARN, ERROR)")
+)
+
+func stringToLogLevel(l string) logging.Level {
+	switch strings.ToLower(l) {
+	case "debug":
+		return logging.DebugLevel
+	case "info":
+		return logging.InfoLevel
+	case "warn":
+		return logging.WarnLevel
+	case "error":
+		return logging.ErrorLevel
+
+	default:
+		return logging.InfoLevel
+	}
+}
+
 func main() {
-	logging.SetLevel(logging.DebugLevel)
+	flag.Parse()
+	logging.SetLevel(stringToLogLevel(*logLevel))
 
 	nodeID := os.Args[1]
 	protocolConfig := parseProtocolConfig()


### PR DESCRIPTION
By default `Atomix` is logging in debug which is printing `IMSI` details which can be security breach. Also that logging level is not configurable.
This PR is to change the default log level from `DEBUG` to `INFO`, which can also be configurable via flag. 